### PR TITLE
fix null pointer exception when info.versionName is null

### DIFF
--- a/lib/models/app.dart
+++ b/lib/models/app.dart
@@ -303,7 +303,7 @@ mixin AppAdapter on Adapter<App> {
 
     final newState = {
       for (final info in installedPackageInfos)
-        info.packageName!: (info.versionName!, info.versionCode!)
+        info.packageName!: (info.versionName??'?', info.versionCode!)
     };
 
     // Providers can't set other providers state


### PR DESCRIPTION
Avoid NPE and use a placeholder '?' when versionName is null.
Fixes #119 
![Screenshot from 2024-09-03 13-25-26](https://github.com/user-attachments/assets/b0dcdf6e-b52d-4580-82d5-c5cdba1a1d2a)
