### PR TITLE
Add web links handling

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
+            <meta-data android:name="flutter_deeplinking_enabled" android:value="false" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
@@ -37,6 +38,15 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="zapstore" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:host="zapstore.dev" />
+                <data android:pathPrefix="/download"/>
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/lib/navigation/app_initializer.dart
+++ b/lib/navigation/app_initializer.dart
@@ -55,18 +55,24 @@ final appInitializer = FutureProvider<void>((ref) async {
 
   // Handle deep links
   final appLinksSub = appLinks.uriLinkStream.listen((uri) async {
-    if (uri.scheme == 'zapstore') {
+    String? appId;
+    if (uri.scheme == 'https' && uri.hasFragment) {
+      appId = uri.fragment;
+    } else if (uri.scheme == 'zapstore') {
+      appId = uri.host;
+    }
+    if (appId != null) {
       final adapter = ref.apps.appAdapter;
-      final apps = adapter.findWhereIdentifierInLocal({uri.host});
+      final apps = adapter.findWhereIdentifierInLocal({appId});
       // Filter by signer npub, if present, otherwise pick first
       final appSignerNpub = uri.queryParameters['signer'];
-      var app =
+      var goToApp =
           apps.firstWhereOrNull((a) => a.signer.value?.npub == appSignerNpub);
       if (appSignerNpub == null) {
-        app = apps.first;
+        goToApp = apps.first;
       }
-      if (app != null) {
-        appRouter.go('/details', extra: app);
+      if (goToApp != null) {
+        appRouter.go('/details', extra: goToApp);
       } else {
         appRouter.go('/');
       }


### PR DESCRIPTION
https://zapstore.dev/download#app will now open the app details screen if zapstore is installed, otherwise will show web page for download in browser.
This should be the standard way of linking buttons to install a certain app using zapstore.
Because the existing zapstore://app will not do anything if user still doesn't have zapstore installed.