### PR TITLE
Add AGENTS.md entry point for AI coding assistants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AI Agents
+
+Start here: [CONTEXT.md](CONTEXT.md)
+
+## Quick Reference
+
+| What | Where |
+|------|-------|
+| Project overview | `CONTEXT.md` |
+| Architecture & patterns | `spec/guidelines/ARCHITECTURE.md` |
+| Non-negotiable rules | `spec/guidelines/INVARIANTS.md` |
+| Quality standards | `spec/guidelines/QUALITY_BAR.md` |
+| Product vision | `spec/guidelines/VISION.md` |
+| Feature specs | `spec/features/` |
+| Active work | `work/` |
+
+## Rules
+
+1. Read `CONTEXT.md` first
+2. Never modify files in `spec/guidelines/`
+3. If a spec is unclear, report it—do not guess


### PR DESCRIPTION
## Summary

Adds a minimal `AGENTS.md` file that serves as the standard entry point for AI coding assistants (Claude Code, GitHub Copilot, Cursor, etc.).

This follows the spec-first documentation system introduced in #271, pointing agents to:
- `CONTEXT.md` as the main entry point
- `spec/guidelines/` for architecture, invariants, quality bar, and vision
- `spec/features/` for feature specs
- `work/` for active work packets

## References

- Implements the AGENTS.md convention referenced in https://github.com/zapstore/zapstore/pull/271
- Inspired by [notedeck AGENTS.md](https://github.com/damus-io/notedeck/blob/master/AGENTS.md)

Signed-off-by: alltheseas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal project documentation with reference guidelines and quick reference materials.

**Note:** This release contains no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->