### PR TITLE
Hide "Always trust" toggle when user is not signed in

### DIFF
--- a/lib/widgets/install_alert_dialog.dart
+++ b/lib/widgets/install_alert_dialog.dart
@@ -84,37 +84,40 @@ class InstallAlertDialog extends HookConsumerWidget {
                       ),
                     ],
                   ),
-            const Gap(14),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Switch(
-                  value: trustedSignerNotifier.value,
-                  onChanged: (value) {
-                    trustedSignerNotifier.value = value;
-                  },
-                ),
-                Gap(4),
-                Expanded(
-                  child: Row(
-                    children: [
-                      Text(
-                        'Always trust',
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.onSurface,
-                        ),
-                      ),
-                      Gap(4),
-                      AuthorContainer(
-                        beforeText: '',
-                        profile: publisher,
-                        size: baseTextSize,
-                      ),
-                    ],
+            // Only show "Always trust" when signed in (requires signer to persist)
+            if (profile != null) ...[
+              const Gap(14),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Switch(
+                    value: trustedSignerNotifier.value,
+                    onChanged: (value) {
+                      trustedSignerNotifier.value = value;
+                    },
                   ),
-                ),
-              ],
-            ),
+                  Gap(4),
+                  Expanded(
+                    child: Row(
+                      children: [
+                        Text(
+                          'Always trust',
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.onSurface,
+                          ),
+                        ),
+                        Gap(4),
+                        AuthorContainer(
+                          beforeText: '',
+                          profile: publisher,
+                          size: baseTextSize,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ],
           ],
         ],
       ),


### PR DESCRIPTION
The "Always trust" switch was showing for users who are not signed in. Since persisting trust requires a signer, toggling it without being signed in silently did nothing — the preference was never saved, and the dialog would show again on the next install.

This hides the toggle when the user is not signed in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Always trust" option now only displays for signed-in users. This setting was previously visible to anonymous users but is now restricted to authenticated accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->