### PR TITLE
Backup and restore installed apps (Issue #20)

### DIFF
--- a/lib/constants/app_constants.dart
+++ b/lib/constants/app_constants.dart
@@ -12,15 +12,20 @@ const kFranzapPubkey =
 /// Identifier for storing user saved apps
 const kAppBookmarksIdentifier = 'zapstore-bookmarks';
 
+/// Identifier for encrypted backup of installed apps
+const kInstalledAppsBackupIdentifier = 'zapstore-installed';
+
 /// Event filter for app stacks - excludes saved apps and stacks with zero App references
 bool appStackEventFilter(Map<String, dynamic> event) {
   final tags = event['tags'] as List<dynamic>?;
   if (tags == null) return false;
 
-  // Check for saved apps identifier in 'd' tag
+  // Check for saved apps / backup identifiers in 'd' tag (exclude from public stacks)
   for (final tag in tags) {
     if (tag is List && tag.isNotEmpty && tag[0] == 'd') {
-      if (tag.length > 1 && tag[1] == kAppBookmarksIdentifier) {
+      if (tag.length > 1 &&
+          (tag[1] == kAppBookmarksIdentifier ||
+              tag[1] == kInstalledAppsBackupIdentifier)) {
         return false;
       }
     }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -11,7 +11,6 @@ import 'package:zapstore/screens/user_screen.dart';
 import 'package:zapstore/screens/search_screen.dart';
 import 'package:zapstore/screens/updates_screen.dart';
 import 'package:zapstore/screens/profile_screen.dart';
-import 'package:zapstore/screens/restore_installed_apps_screen.dart';
 import 'package:zapstore/services/package_manager/package_manager.dart';
 
 /// Root paths for each navigation branch (used for back navigation handling)
@@ -79,25 +78,6 @@ GoRoute _stackDetailRoute() {
           stackId: resolved.identifier,
           authorPubkey: resolved.author,
         ),
-      );
-    },
-  );
-}
-
-/// Helper to build restore installed apps route
-GoRoute _restoreRoute() {
-  return GoRoute(
-    path: 'restore',
-    redirect: (context, state) {
-      final extra = state.extra;
-      if (extra is! List<String> || extra.isEmpty) return '/profile';
-      return null;
-    },
-    pageBuilder: (context, state) {
-      final ids = state.extra as List<String>;
-      return _noTransitionPage(
-        state: state,
-        child: RestoreInstalledAppsScreen(addressableIds: ids),
       );
     },
   );
@@ -180,7 +160,6 @@ final routerProvider = Provider<GoRouter>((ref) {
                   _appDetailRoute(),
                   _stackDetailRoute(),
                   _userRoute(),
-                  _restoreRoute(),
                 ],
               ),
             ],

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -11,6 +11,7 @@ import 'package:zapstore/screens/user_screen.dart';
 import 'package:zapstore/screens/search_screen.dart';
 import 'package:zapstore/screens/updates_screen.dart';
 import 'package:zapstore/screens/profile_screen.dart';
+import 'package:zapstore/screens/restore_installed_apps_screen.dart';
 import 'package:zapstore/services/package_manager/package_manager.dart';
 
 /// Root paths for each navigation branch (used for back navigation handling)
@@ -78,6 +79,25 @@ GoRoute _stackDetailRoute() {
           stackId: resolved.identifier,
           authorPubkey: resolved.author,
         ),
+      );
+    },
+  );
+}
+
+/// Helper to build restore installed apps route
+GoRoute _restoreRoute() {
+  return GoRoute(
+    path: 'restore',
+    redirect: (context, state) {
+      final extra = state.extra;
+      if (extra is! List<String> || extra.isEmpty) return '/profile';
+      return null;
+    },
+    pageBuilder: (context, state) {
+      final ids = state.extra as List<String>;
+      return _noTransitionPage(
+        state: state,
+        child: RestoreInstalledAppsScreen(addressableIds: ids),
       );
     },
   );
@@ -156,7 +176,12 @@ final routerProvider = Provider<GoRouter>((ref) {
                   state: state,
                   child: const ProfileScreen(),
                 ),
-                routes: [_appDetailRoute(), _stackDetailRoute(), _userRoute()],
+                routes: [
+                  _appDetailRoute(),
+                  _stackDetailRoute(),
+                  _userRoute(),
+                  _restoreRoute(),
+                ],
               ),
             ],
           ),

--- a/lib/screens/main_scaffold.dart
+++ b/lib/screens/main_scaffold.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:models/models.dart';
 import 'package:zapstore/router.dart';
+import 'package:zapstore/services/installed_apps_backup_service.dart';
 import 'package:zapstore/services/updates_service.dart';
 import 'package:zapstore/widgets/common/badges.dart';
 import '../widgets/common/profile_avatar.dart';
@@ -118,6 +119,7 @@ class MobileScaffold extends ConsumerWidget {
     // Watch categorized to keep poller alive (poller is watched by categorized)
     final categorized = ref.watch(categorizedUpdatesProvider);
     final poller = ref.watch(updatePollerProvider);
+    ref.watch(installedAppsBackupListenerProvider);
     final updateCount = ref.watch(updateCountProvider);
     final isLoadingUpdates = categorized.showSkeleton || poller.isChecking;
 
@@ -308,6 +310,7 @@ class DesktopScaffold extends ConsumerWidget {
     // Watch categorized to keep poller alive (poller is watched by categorized)
     final categorized = ref.watch(categorizedUpdatesProvider);
     final poller = ref.watch(updatePollerProvider);
+    ref.watch(installedAppsBackupListenerProvider);
     final updateCount = ref.watch(updateCountProvider);
     final isLoadingUpdates = categorized.showSkeleton || poller.isChecking;
 

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -15,6 +15,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:purplebase/purplebase.dart';
 import 'package:zapstore/main.dart';
 import 'package:zapstore/services/bookmarks_service.dart';
+import 'package:zapstore/services/installed_apps_backup_service.dart';
 import 'package:zapstore/services/package_manager/package_manager.dart';
 import 'package:zapstore/utils/extensions.dart';
 import 'package:zapstore/widgets/common/profile_identity_row.dart';
@@ -1334,6 +1335,90 @@ class _EmptyState extends StatelessWidget {
   }
 }
 
+class _InstalledAppsTile extends ConsumerWidget {
+  const _InstalledAppsTile({
+    required this.icon,
+    required this.title,
+    required this.onAction,
+  });
+
+  final IconData icon;
+  final String title;
+  final Future<void> Function(BuildContext context, WidgetRef ref) onAction;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final signedInPubkey = ref.watch(Signer.activePubkeyProvider);
+    final isSignedIn = signedInPubkey != null;
+
+    return AsyncButtonBuilder(
+      onPressed: () async {
+        if (!isSignedIn) {
+          if (context.mounted) {
+            context.showError(
+              'Sign in required',
+              description: 'You need to sign in to use this feature.',
+            );
+          }
+          return;
+        }
+        try {
+          await onAction(context, ref);
+        } catch (e) {
+          if (context.mounted) {
+            context.showError(
+              'Operation failed',
+              technicalDetails: '$e',
+            );
+          }
+        }
+      },
+      builder: (context, child, callback, buttonState) {
+        final isLoading = buttonState.maybeWhen(
+          loading: () => true,
+          orElse: () => false,
+        );
+        return ListTile(
+          leading: CircleAvatar(
+            radius: 18,
+            backgroundColor: Theme.of(context)
+                .colorScheme
+                .primary
+                .withValues(alpha: 0.12),
+            child: isLoading
+                ? SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                  )
+                : Icon(
+                    icon,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+          ),
+          title: AutoSizeText(
+            title,
+            style: TextStyle(
+              color: isSignedIn
+                  ? Theme.of(context).colorScheme.onSurface
+                  : Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.5),
+              fontWeight: FontWeight.w600,
+            ),
+            maxLines: 1,
+            minFontSize: 12,
+          ),
+          contentPadding: EdgeInsets.zero,
+          onTap: isLoading || !isSignedIn ? null : callback,
+        );
+      },
+      child: const SizedBox.shrink(),
+    );
+  }
+}
+
 class _DataManagementSection extends ConsumerWidget {
   const _DataManagementSection();
 
@@ -1350,6 +1435,33 @@ class _DataManagementSection extends ConsumerWidget {
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: 16),
+            _InstalledAppsTile(
+              icon: Icons.backup,
+              title: 'Backup installed apps',
+              onAction: (context, ref) async {
+                final count = await ref.read(backupInstalledAppsProvider)();
+                if (context.mounted) {
+                  context.showInfo(
+                    count == 0
+                        ? 'No cataloged apps to backup'
+                        : 'Backed up $count app${count == 1 ? '' : 's'}',
+                  );
+                }
+              },
+            ),
+            _InstalledAppsTile(
+              icon: Icons.restore,
+              title: 'Restore installed apps',
+              onAction: (context, ref) async {
+                final ids = await ref.read(restoreInstalledAppsProvider)();
+                if (!context.mounted) return;
+                if (ids.isEmpty) {
+                  context.showInfo('No backup found');
+                  return;
+                }
+                context.push('/profile/restore', extra: ids);
+              },
+            ),
             ListTile(
               leading: CircleAvatar(
                 radius: 18,

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -15,6 +15,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:purplebase/purplebase.dart';
 import 'package:zapstore/main.dart';
 import 'package:zapstore/services/bookmarks_service.dart';
+import 'package:zapstore/screens/restore_installed_apps_screen.dart';
 import 'package:zapstore/services/installed_apps_backup_service.dart';
 import 'package:zapstore/services/package_manager/package_manager.dart';
 import 'package:zapstore/utils/extensions.dart';
@@ -186,17 +187,11 @@ class _AuthenticationSection extends ConsumerWidget {
         FilledButton.icon(
           onPressed: () => _signOut(context, ref),
           icon: const Icon(Icons.logout, size: 14),
-          label: const Text(
-            'Sign Out',
-            style: TextStyle(fontSize: 12),
-          ),
+          label: const Text('Sign Out', style: TextStyle(fontSize: 12)),
           style: FilledButton.styleFrom(
             backgroundColor: Colors.red.shade900,
             foregroundColor: Colors.white,
-            padding: const EdgeInsets.symmetric(
-              horizontal: 12,
-              vertical: 6,
-            ),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
             minimumSize: const Size(0, 0),
             tapTargetSize: MaterialTapTargetSize.shrinkWrap,
           ),
@@ -1366,10 +1361,7 @@ class _InstalledAppsTile extends ConsumerWidget {
           await onAction(context, ref);
         } catch (e) {
           if (context.mounted) {
-            context.showError(
-              'Operation failed',
-              technicalDetails: '$e',
-            );
+            context.showError('Operation failed', technicalDetails: '$e');
           }
         }
       },
@@ -1381,10 +1373,9 @@ class _InstalledAppsTile extends ConsumerWidget {
         return ListTile(
           leading: CircleAvatar(
             radius: 18,
-            backgroundColor: Theme.of(context)
-                .colorScheme
-                .primary
-                .withValues(alpha: 0.12),
+            backgroundColor: Theme.of(
+              context,
+            ).colorScheme.primary.withValues(alpha: 0.12),
             child: isLoading
                 ? SizedBox(
                     width: 20,
@@ -1394,17 +1385,16 @@ class _InstalledAppsTile extends ConsumerWidget {
                       color: Theme.of(context).colorScheme.primary,
                     ),
                   )
-                : Icon(
-                    icon,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
+                : Icon(icon, color: Theme.of(context).colorScheme.primary),
           ),
           title: AutoSizeText(
             title,
             style: TextStyle(
               color: isSignedIn
                   ? Theme.of(context).colorScheme.onSurface
-                  : Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.5),
+                  : Theme.of(
+                      context,
+                    ).colorScheme.onSurface.withValues(alpha: 0.5),
               fontWeight: FontWeight.w600,
             ),
             maxLines: 1,
@@ -1424,6 +1414,10 @@ class _DataManagementSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final pubkey = ref.watch(Signer.activePubkeyProvider);
+    final backupEnabled =
+        ref.watch(backupSettingsProvider).valueOrNull ?? false;
+
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -1435,6 +1429,23 @@ class _DataManagementSection extends ConsumerWidget {
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: 16),
+            if (pubkey != null)
+              SwitchListTile(
+                secondary: Icon(
+                  Icons.cloud_upload_outlined,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                title: const Text('Enable installed apps backup'),
+                subtitle: const Text(
+                  'Automatically syncs your installed apps list to Nostr after each install or uninstall.',
+                ),
+                value: backupEnabled,
+                onChanged: (value) {
+                  ref.read(backupSettingsProvider.notifier).setEnabled(value);
+                },
+                contentPadding: EdgeInsets.zero,
+              ),
+            if (pubkey != null) const SizedBox(height: 8),
             _InstalledAppsTile(
               icon: Icons.backup,
               title: 'Backup installed apps',
@@ -1459,7 +1470,30 @@ class _DataManagementSection extends ConsumerWidget {
                   context.showInfo('No backup found');
                   return;
                 }
-                context.push('/profile/restore', extra: ids);
+                await showDialog<void>(
+                  context: context,
+                  useRootNavigator: true,
+                  barrierDismissible: false,
+                  builder: (dialogContext) => PopScope(
+                    canPop: false,
+                    onPopInvokedWithResult: (didPop, _) {
+                      if (!didPop) {
+                        Navigator.of(dialogContext, rootNavigator: true).pop();
+                      }
+                    },
+                    child: Dialog(
+                      backgroundColor: AppColors.darkBackground,
+                      insetPadding: EdgeInsets.zero,
+                      child: RestoreInstalledAppsScreen(
+                        addressableIds: ids,
+                        onClose: () => Navigator.of(
+                          dialogContext,
+                          rootNavigator: true,
+                        ).pop(),
+                      ),
+                    ),
+                  ),
+                );
               },
             ),
             ListTile(

--- a/lib/screens/restore_installed_apps_screen.dart
+++ b/lib/screens/restore_installed_apps_screen.dart
@@ -9,15 +9,30 @@ import 'package:zapstore/widgets/batch_progress_banner.dart';
 import 'package:zapstore/widgets/common/badges.dart';
 import 'package:zapstore/theme.dart';
 
+/// Shared AppBar for restore screen (empty, loading, error, content).
+PreferredSizeWidget _restoreAppBar({VoidCallback? onClose}) {
+  return AppBar(
+    title: const Text('Restore from backup'),
+    leading: onClose != null
+        ? IconButton(icon: const Icon(Icons.close), onPressed: onClose)
+        : null,
+    automaticallyImplyLeading: onClose == null,
+  );
+}
+
 /// Full-screen restore from backup. Mirrors [AppStackScreen] pattern:
 /// query with nested relations, skeleton on loading, sort uninstalled first.
 class RestoreInstalledAppsScreen extends HookConsumerWidget {
   const RestoreInstalledAppsScreen({
     super.key,
     required this.addressableIds,
+    this.onClose,
   });
 
   final List<String> addressableIds;
+
+  /// Called when user closes the modal. Required when shown as overlay.
+  final VoidCallback? onClose;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -28,15 +43,9 @@ class RestoreInstalledAppsScreen extends HookConsumerWidget {
 
     if (appIdentifiers.isEmpty) {
       return Scaffold(
-        appBar: AppBar(
-          title: const Text('Restore from backup'),
-          automaticallyImplyLeading: false,
-        ),
+        appBar: _restoreAppBar(onClose: onClose),
         body: Center(
-          child: Text(
-            'No apps to restore',
-            style: context.textTheme.bodyLarge,
-          ),
+          child: Text('No apps to restore', style: context.textTheme.bodyLarge),
         ),
       );
     }
@@ -64,38 +73,33 @@ class RestoreInstalledAppsScreen extends HookConsumerWidget {
 
     return switch (appsState) {
       StorageLoading() => Scaffold(
-          appBar: AppBar(
-            title: const Text('Restore from backup'),
-            automaticallyImplyLeading: false,
-          ),
-          body: SingleChildScrollView(
-            padding: const EdgeInsets.only(top: 8, bottom: 32),
-            child: _RestoreSkeleton(),
-          ),
+        appBar: _restoreAppBar(onClose: onClose),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.only(top: 8, bottom: 32),
+          child: _RestoreSkeleton(),
         ),
+      ),
       StorageError(:final exception) => Scaffold(
-          appBar: AppBar(
-            title: const Text('Restore from backup'),
-            automaticallyImplyLeading: false,
-          ),
-          body: Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                const Icon(Icons.error_outline, size: 64),
-                const SizedBox(height: 12),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 24),
-                  child: Text(exception.toString(), textAlign: TextAlign.center),
-                ),
-              ],
-            ),
+        appBar: _restoreAppBar(onClose: onClose),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.error_outline, size: 64),
+              const SizedBox(height: 12),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: Text(exception.toString(), textAlign: TextAlign.center),
+              ),
+            ],
           ),
         ),
+      ),
       StorageData(:final models) => _RestoreContent(
-          allApps: models,
-          appIdentifiers: appIdentifiers,
-        ),
+        allApps: models,
+        appIdentifiers: appIdentifiers,
+        onClose: onClose,
+      ),
     };
   }
 }
@@ -104,15 +108,29 @@ class _RestoreContent extends HookConsumerWidget {
   const _RestoreContent({
     required this.allApps,
     required this.appIdentifiers,
+    this.onClose,
   });
 
   final List<App> allApps;
   final Set<String> appIdentifiers;
+  final VoidCallback? onClose;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final installedIds =
-        ref.watch(packageManagerProvider).installed.keys.toSet();
+    final installedIds = ref
+        .watch(packageManagerProvider)
+        .installed
+        .keys
+        .toSet();
+    final completedOperationIds = ref.watch(
+      packageManagerProvider.select(
+        (s) => s.operations.entries
+            .where((entry) => entry.value is Completed)
+            .map((entry) => entry.key)
+            .toSet(),
+      ),
+    );
+    final effectiveInstalledIds = {...installedIds, ...completedOperationIds};
 
     final appsMap = {for (final app in allApps) app.identifier: app};
 
@@ -120,26 +138,27 @@ class _RestoreContent extends HookConsumerWidget {
     final toInstall = appIdentifiers
         .map((id) => appsMap[id])
         .whereType<App>()
-        .where((app) => !installedIds.contains(app.identifier))
+        .where((app) => !effectiveInstalledIds.contains(app.identifier))
         .toList();
 
     final alreadyInstalled = appIdentifiers
         .map((id) => appsMap[id])
         .whereType<App>()
-        .where((app) => installedIds.contains(app.identifier))
+        .where((app) => effectiveInstalledIds.contains(app.identifier))
         .toList();
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Restore from backup'),
-        automaticallyImplyLeading: false,
-      ),
+      appBar: _restoreAppBar(onClose: onClose),
       body: ListView(
         padding: const EdgeInsets.only(top: 8, bottom: 32),
         children: [
           // "Install All" button — same style as UpdateAllRow in updates screen
           if (toInstall.length > 1)
-            UpdateAllRow(allUpdates: toInstall, label: 'Install All'),
+            UpdateAllRow(
+              allUpdates: toInstall,
+              label: 'Install All',
+              installSource: InstallSource.restore,
+            ),
 
           // "To install" section
           if (toInstall.isNotEmpty)
@@ -152,11 +171,14 @@ class _RestoreContent extends HookConsumerWidget {
             (app) => AppCard(
               key: ValueKey('restore_${app.identifier}'),
               app: app,
+              installSource: InstallSource.restore,
               showUpdateButton: true,
+              showInstallWhenNotInstalled: true,
               showUpdateArrow: false,
               showSignedBy: false,
               showZapEncouragement: false,
               showDescription: false,
+              onTap: () {}, // No navigation; Install button stays tappable
             ),
           ),
 
@@ -177,6 +199,7 @@ class _RestoreContent extends HookConsumerWidget {
                 showSignedBy: false,
                 showZapEncouragement: false,
                 showDescription: false,
+                ignorePointer: true, // Informational only; no tap
               ),
             ),
           ],
@@ -189,8 +212,9 @@ class _RestoreContent extends HookConsumerWidget {
                 child: Text(
                   'No apps found in backup',
                   style: context.textTheme.bodyLarge?.copyWith(
-                    color:
-                        Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.onSurface.withValues(alpha: 0.6),
                   ),
                 ),
               ),

--- a/lib/screens/restore_installed_apps_screen.dart
+++ b/lib/screens/restore_installed_apps_screen.dart
@@ -1,0 +1,275 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:models/models.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:zapstore/services/package_manager/package_manager.dart';
+import 'package:zapstore/utils/extensions.dart';
+import 'package:zapstore/widgets/app_card.dart';
+import 'package:zapstore/widgets/batch_progress_banner.dart';
+import 'package:zapstore/widgets/common/badges.dart';
+import 'package:zapstore/theme.dart';
+
+/// Full-screen restore from backup. Mirrors [AppStackScreen] pattern:
+/// query with nested relations, skeleton on loading, sort uninstalled first.
+class RestoreInstalledAppsScreen extends HookConsumerWidget {
+  const RestoreInstalledAppsScreen({
+    super.key,
+    required this.addressableIds,
+  });
+
+  final List<String> addressableIds;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final appIdentifiers = addressableIds
+        .where((id) => id.startsWith('32267:'))
+        .map((id) => id.split(':').skip(2).join(':'))
+        .toSet();
+
+    if (appIdentifiers.isEmpty) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('Restore from backup'),
+          automaticallyImplyLeading: false,
+        ),
+        body: Center(
+          child: Text(
+            'No apps to restore',
+            style: context.textTheme.bodyLarge,
+          ),
+        ),
+      );
+    }
+
+    final platform = ref.read(packageManagerProvider.notifier).platform;
+
+    final appsState = ref.watch(
+      query<App>(
+        tags: {
+          '#d': appIdentifiers,
+          '#f': {platform},
+        },
+        and: (app) => {
+          app.latestRelease.query(
+            and: (release) => {
+              release.latestMetadata.query(),
+              release.latestAsset.query(),
+            },
+          ),
+        },
+        source: const LocalAndRemoteSource(relays: 'AppCatalog', stream: false),
+        subscriptionPrefix: 'restore-backup-apps',
+      ),
+    );
+
+    return switch (appsState) {
+      StorageLoading() => Scaffold(
+          appBar: AppBar(
+            title: const Text('Restore from backup'),
+            automaticallyImplyLeading: false,
+          ),
+          body: SingleChildScrollView(
+            padding: const EdgeInsets.only(top: 8, bottom: 32),
+            child: _RestoreSkeleton(),
+          ),
+        ),
+      StorageError(:final exception) => Scaffold(
+          appBar: AppBar(
+            title: const Text('Restore from backup'),
+            automaticallyImplyLeading: false,
+          ),
+          body: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Icon(Icons.error_outline, size: 64),
+                const SizedBox(height: 12),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: Text(exception.toString(), textAlign: TextAlign.center),
+                ),
+              ],
+            ),
+          ),
+        ),
+      StorageData(:final models) => _RestoreContent(
+          allApps: models,
+          appIdentifiers: appIdentifiers,
+        ),
+    };
+  }
+}
+
+class _RestoreContent extends HookConsumerWidget {
+  const _RestoreContent({
+    required this.allApps,
+    required this.appIdentifiers,
+  });
+
+  final List<App> allApps;
+  final Set<String> appIdentifiers;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final installedIds =
+        ref.watch(packageManagerProvider).installed.keys.toSet();
+
+    final appsMap = {for (final app in allApps) app.identifier: app};
+
+    // Preserve backup order for both lists
+    final toInstall = appIdentifiers
+        .map((id) => appsMap[id])
+        .whereType<App>()
+        .where((app) => !installedIds.contains(app.identifier))
+        .toList();
+
+    final alreadyInstalled = appIdentifiers
+        .map((id) => appsMap[id])
+        .whereType<App>()
+        .where((app) => installedIds.contains(app.identifier))
+        .toList();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Restore from backup'),
+        automaticallyImplyLeading: false,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.only(top: 8, bottom: 32),
+        children: [
+          // "Install All" button — same style as UpdateAllRow in updates screen
+          if (toInstall.length > 1)
+            UpdateAllRow(allUpdates: toInstall, label: 'Install All'),
+
+          // "To install" section
+          if (toInstall.isNotEmpty)
+            _SectionHeader(
+              icon: Icons.download_outlined,
+              title: 'To install',
+              count: toInstall.length,
+            ),
+          ...toInstall.map(
+            (app) => AppCard(
+              key: ValueKey('restore_${app.identifier}'),
+              app: app,
+              showUpdateButton: true,
+              showUpdateArrow: false,
+              showSignedBy: false,
+              showZapEncouragement: false,
+              showDescription: false,
+            ),
+          ),
+
+          // "Already installed" section
+          if (alreadyInstalled.isNotEmpty) ...[
+            _SectionHeader(
+              icon: Icons.check_circle,
+              title: 'Already installed',
+              count: alreadyInstalled.length,
+              iconColor: Colors.green.shade400,
+            ),
+            ...alreadyInstalled.map(
+              (app) => AppCard(
+                key: ValueKey('installed_${app.identifier}'),
+                app: app,
+                showUpdateButton: false,
+                showUpdateArrow: app.hasUpdate,
+                showSignedBy: false,
+                showZapEncouragement: false,
+                showDescription: false,
+              ),
+            ),
+          ],
+
+          // Empty state — only when backup has nothing at all
+          if (toInstall.isEmpty && alreadyInstalled.isEmpty)
+            Padding(
+              padding: const EdgeInsets.all(32),
+              child: Center(
+                child: Text(
+                  'No apps found in backup',
+                  style: context.textTheme.bodyLarge?.copyWith(
+                    color:
+                        Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({
+    required this.icon,
+    required this.title,
+    required this.count,
+    this.iconColor,
+  });
+
+  final IconData icon;
+  final String title;
+  final int count;
+  final Color? iconColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        children: [
+          Icon(icon, size: 20, color: iconColor ?? AppColors.darkActionPrimary),
+          const SizedBox(width: 8),
+          Text(title, style: context.textTheme.titleMedium),
+          const SizedBox(width: 8),
+          CountBadge(count: count, color: AppColors.darkPillBackground),
+        ],
+      ),
+    );
+  }
+}
+
+class _RestoreSkeleton extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SkeletonizerConfig(
+      data: AppColors.getSkeletonizerConfig(Theme.of(context).brightness),
+      child: Skeletonizer(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Section header skeleton — same padding as _SectionHeader
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  Container(
+                    height: 20,
+                    width: 100,
+                    decoration: BoxDecoration(
+                      color: AppColors.darkSkeletonBase,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Container(
+                    height: 20,
+                    width: 24,
+                    decoration: BoxDecoration(
+                      color: AppColors.darkSkeletonBase,
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 4),
+            ...List.generate(3, (_) => const AppCard(isLoading: true)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/installed_apps_backup_service.dart
+++ b/lib/services/installed_apps_backup_service.dart
@@ -1,0 +1,124 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:models/models.dart';
+import 'package:zapstore/constants/app_constants.dart';
+import 'package:zapstore/services/package_manager/package_manager.dart';
+import 'package:zapstore/utils/extensions.dart';
+
+/// Provider that exposes the backup function with correct Ref.
+final backupInstalledAppsProvider = Provider<Future<int> Function()>((ref) {
+  return () => _backupInstalledApps(ref);
+});
+
+/// Backs up the list of cataloged installed apps as an encrypted AppStack (kind 30267)
+/// to Nostr social relays. Only apps that are both installed and in the Zapstore
+/// catalog are included.
+///
+/// Returns the count of backed-up apps.
+/// Throws if user is not signed in or on failure.
+Future<int> _backupInstalledApps(Ref ref) async {
+  final signer = ref.read(Signer.activeSignerProvider);
+  final signedInPubkey = ref.read(Signer.activePubkeyProvider);
+
+  if (signer == null || signedInPubkey == null) {
+    throw StateError('Sign in required to backup installed apps');
+  }
+
+  final pmState = ref.read(packageManagerProvider);
+  final installedIds = pmState.installed.keys.toSet();
+
+  if (installedIds.isEmpty) {
+    return _saveBackup(ref, signer, []);
+  }
+
+  final platform = ref.read(packageManagerProvider.notifier).platform;
+  final storage = ref.read(storageNotifierProvider.notifier);
+
+  final apps = await storage.query(
+    RequestFilter<App>(
+      tags: {
+        '#d': installedIds,
+        '#f': {platform},
+      },
+    ).toRequest(subscriptionPrefix: 'installed-backup'),
+    source: const LocalSource(),
+  );
+
+  final appIds = apps
+      .map((app) => '${app.event.kind}:${app.pubkey}:${app.identifier}')
+      .toList();
+
+  return _saveBackup(ref, signer, appIds);
+}
+
+Future<int> _saveBackup(Ref ref, Signer signer, List<String> appIds) async {
+  final platform = ref.read(packageManagerProvider.notifier).platform;
+  final storage = ref.read(storageNotifierProvider.notifier);
+
+  final partialStack = PartialAppStack.withEncryptedApps(
+    name: 'Installed Apps',
+    identifier: kInstalledAppsBackupIdentifier,
+    apps: appIds,
+    platform: platform,
+  );
+
+  final signedStack = await partialStack.signWith(signer);
+
+  await storage.save({signedStack});
+
+  storage.publish(
+    {signedStack},
+    source: RemoteSource(relays: 'social'),
+  );
+
+  return appIds.length;
+}
+
+/// Provider that exposes the restore function with correct Ref.
+/// Returns decrypted addressable IDs from the backup (lightweight, no catalog queries).
+final restoreInstalledAppsProvider = Provider<Future<List<String>> Function()>((ref) {
+  return () => _restoreInstalledApps(ref);
+});
+
+/// Fetches the encrypted backup from Nostr relays and decrypts it.
+/// Returns raw addressable IDs (e.g. "32267:pubkey:identifier").
+/// The UI is responsible for resolving these to App models reactively.
+Future<List<String>> _restoreInstalledApps(Ref ref) async {
+  final signer = ref.read(Signer.activeSignerProvider);
+  final signedInPubkey = ref.read(Signer.activePubkeyProvider);
+
+  if (signer == null || signedInPubkey == null) {
+    throw StateError('Sign in required to restore installed apps');
+  }
+
+  final storage = ref.read(storageNotifierProvider.notifier);
+
+  final stacks = await storage.query(
+    RequestFilter<AppStack>(
+      authors: {signedInPubkey},
+      tags: {'#d': {kInstalledAppsBackupIdentifier}},
+    ).toRequest(subscriptionPrefix: 'installed-restore'),
+    source: const LocalAndRemoteSource(relays: 'social', stream: false),
+  );
+
+  final stack = stacks.firstOrNull;
+  if (stack == null || stack.content.isEmpty) {
+    return [];
+  }
+
+  List<String> addressableIds;
+  try {
+    final decryptedContent = await signer.nip44Decrypt(
+      stack.content,
+      signedInPubkey,
+    );
+    addressableIds = (jsonDecode(decryptedContent) as List).cast<String>();
+  } catch (e) {
+    debugPrint('[InstalledAppsBackup] Restore decrypt failed: $e');
+    return [];
+  }
+
+  return addressableIds;
+}

--- a/lib/services/installed_apps_backup_service.dart
+++ b/lib/services/installed_apps_backup_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -5,7 +6,134 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:models/models.dart';
 import 'package:zapstore/constants/app_constants.dart';
 import 'package:zapstore/services/package_manager/package_manager.dart';
+import 'package:zapstore/services/secure_storage_service.dart';
 import 'package:zapstore/utils/extensions.dart';
+
+const _logPrefix = '[InstalledAppsBackup]';
+
+/// Persisted setting for auto-backup (off by default). Survives sign-out.
+class BackupSettingsNotifier extends AsyncNotifier<bool> {
+  @override
+  Future<bool> build() async {
+    final storage = ref.read(secureStorageServiceProvider);
+    return storage.getBackupEnabled();
+  }
+
+  Future<void> setEnabled(bool enabled) async {
+    await ref.read(secureStorageServiceProvider).setBackupEnabled(enabled);
+    ref.invalidateSelf();
+  }
+}
+
+final backupSettingsProvider =
+    AsyncNotifierProvider<BackupSettingsNotifier, bool>(
+  BackupSettingsNotifier.new,
+);
+
+const _backupDebounceDuration = Duration(seconds: 3);
+
+/// Listens to batch completion and uninstalls; triggers backup when enabled and signed in.
+/// Debounces rapid triggers (e.g. multiple uninstalls) to avoid repeated sign prompts.
+/// Watched by MainScaffold to keep alive.
+final installedAppsBackupListenerProvider = Provider<void>((ref) {
+  Timer? debounceTimer;
+  var activeBatchAppIds = <String>{};
+  Set<String>? baselineInstalledKeys;
+
+  void scheduleBackup() {
+    debounceTimer?.cancel();
+    debounceTimer = Timer(_backupDebounceDuration, () {
+      debounceTimer = null;
+      _maybeBackup(ref);
+    });
+  }
+
+  ref.listen<BatchProgress?>(batchProgressProvider, (prev, next) {
+    if (next?.hasInProgress == true) {
+      activeBatchAppIds = ref
+          .read(packageManagerProvider)
+          .operations
+          .entries
+          .where((entry) => entry.value.isInProgress)
+          .map((entry) => entry.key)
+          .toSet();
+    }
+
+    final hasBatchCompleted =
+        prev?.hasInProgress == true && next?.isAllComplete == true;
+    if (hasBatchCompleted) {
+      if (baselineInstalledKeys == null) return;
+      if (_isRestoreOnlyBatch(ref, activeBatchAppIds)) {
+        activeBatchAppIds = <String>{};
+        baselineInstalledKeys =
+            ref.read(packageManagerProvider).installed.keys.toSet();
+        return;
+      }
+      baselineInstalledKeys =
+          ref.read(packageManagerProvider).installed.keys.toSet();
+      scheduleBackup();
+      activeBatchAppIds = <String>{};
+    }
+  });
+
+  ref.listen<bool>(
+    packageManagerProvider.select((s) => s.isScanning),
+    (prev, next) {
+      if (prev == true && next == false) {
+        final keys = ref.read(packageManagerProvider).installed.keys.toSet();
+        baselineInstalledKeys ??= keys;
+      }
+    },
+  );
+
+  ref.listen<int>(
+    packageManagerProvider.select((s) => s.installed.length),
+    (prev, next) {
+      if (baselineInstalledKeys == null || prev == null || prev == next) return;
+      final currentKeys =
+          ref.read(packageManagerProvider).installed.keys.toSet();
+      final added = currentKeys.difference(baselineInstalledKeys!);
+      final removed = baselineInstalledKeys!.difference(currentKeys);
+      if (added.isEmpty && removed.isEmpty) return;
+      // Skip isScanning only for additions (avoids false triggers during sync).
+      // Removals are always from user uninstall — must trigger backup.
+      if (removed.isEmpty && ref.read(packageManagerProvider).isScanning) return;
+      final batch = ref.read(batchProgressProvider);
+      if (batch != null && batch.hasInProgress) return;
+      baselineInstalledKeys = currentKeys;
+      scheduleBackup();
+    },
+  );
+
+  ref.onDispose(() {
+    debounceTimer?.cancel();
+  });
+});
+
+void _maybeBackup(Ref ref) {
+  final enabledAsync = ref.read(backupSettingsProvider);
+  final enabled = enabledAsync.valueOrNull ?? false;
+  final pubkey = ref.read(Signer.activePubkeyProvider);
+
+  if (!enabled || pubkey == null) return;
+
+  unawaited(
+    _backupInstalledApps(ref).then((count) {
+      debugPrint('$_logPrefix Backup completed: $count apps');
+    }).catchError((e, st) {
+      debugPrint('$_logPrefix Backup error: $e');
+      debugPrint('$_logPrefix $st');
+    }),
+  );
+}
+
+bool _isRestoreOnlyBatch(Ref ref, Set<String> appIds) {
+  if (appIds.isEmpty) return false;
+  final pm = ref.read(packageManagerProvider.notifier);
+  return appIds.every(
+    (appId) => pm.getOperationSource(appId) == InstallSource.restore,
+  );
+}
 
 /// Provider that exposes the backup function with correct Ref.
 final backupInstalledAppsProvider = Provider<Future<int> Function()>((ref) {
@@ -116,7 +244,7 @@ Future<List<String>> _restoreInstalledApps(Ref ref) async {
     );
     addressableIds = (jsonDecode(decryptedContent) as List).cast<String>();
   } catch (e) {
-    debugPrint('[InstalledAppsBackup] Restore decrypt failed: $e');
+    debugPrint('$_logPrefix Restore decrypt failed: $e');
     return [];
   }
 

--- a/lib/services/package_manager/android_package_manager.dart
+++ b/lib/services/package_manager/android_package_manager.dart
@@ -358,11 +358,15 @@ final class AndroidPackageManager extends PackageManager {
   }
 
   @override
-  void setOperation(String appId, InstallOperation op) {
+  void setOperation(
+    String appId,
+    InstallOperation op, {
+    InstallSource? source,
+  }) {
     // Clear from aborted orphans when a new operation is set,
     // so we can abort again if it becomes orphaned in a future session.
     _abortedOrphans.remove(appId);
-    super.setOperation(appId, op);
+    super.setOperation(appId, op, source: source);
   }
 
   @override

--- a/lib/services/package_manager/install_operation.dart
+++ b/lib/services/package_manager/install_operation.dart
@@ -1,5 +1,18 @@
 import 'package:models/models.dart';
 
+/// Source that initiated an install/download operation.
+enum InstallSource {
+  normal,
+  restore;
+
+  static InstallSource fromMetadata(String? value) {
+    return switch (value) {
+      'restore' => InstallSource.restore,
+      _ => InstallSource.normal,
+    };
+  }
+}
+
 /// Stale download threshold - operations older than this will be cleaned up
 const staleOperationThreshold = Duration(days: 7);
 

--- a/lib/services/package_manager/installed_packages_snapshot.dart
+++ b/lib/services/package_manager/installed_packages_snapshot.dart
@@ -17,7 +17,7 @@ class InstalledPackagesSnapshot {
   static Future<void> save(Map<String, PackageInfo> installed) async {
     try {
       final file = await _file();
-      final tmp = File('${file.path}.tmp');
+      await Directory(path.dirname(file.path)).create(recursive: true);
       final list = installed.values
           .map(
             (p) => <String, dynamic>{
@@ -35,11 +35,7 @@ class InstalledPackagesSnapshot {
         'savedAt': DateTime.now().millisecondsSinceEpoch,
         'installed': list,
       });
-      await tmp.writeAsString(payload, flush: true);
-      if (await file.exists()) {
-        await file.delete();
-      }
-      await tmp.rename(file.path);
+      await file.writeAsString(payload, flush: true);
     } catch (e) {
       // Best-effort snapshot only.
       if (kDebugMode) {

--- a/lib/services/package_manager/package_manager.dart
+++ b/lib/services/package_manager/package_manager.dart
@@ -134,6 +134,9 @@ abstract class PackageManager extends StateNotifier<PackageManagerState> {
   /// Lock to prevent concurrent queue processing
   bool _processingQueue = false;
 
+  /// Tracks the source for each app operation (normal vs restore).
+  final Map<String, InstallSource> _operationSourceByAppId = {};
+
   /// Dynamic max concurrent downloads based on device capability
   int get maxConcurrentDownloads =>
       DeviceCapabilitiesCache.capabilities.maxConcurrentDownloads;
@@ -294,16 +297,30 @@ abstract class PackageManager extends StateNotifier<PackageManagerState> {
       .map((e) => e.key)
       .toList();
 
+  InstallSource getOperationSource(String appId) {
+    return _operationSourceByAppId[appId] ?? InstallSource.normal;
+  }
+
   // ═══════════════════════════════════════════════════════════════════════════
   // STATE MANAGEMENT (Public for subclass use)
   // ═══════════════════════════════════════════════════════════════════════════
 
-  void setOperation(String appId, InstallOperation op) {
+  void setOperation(
+    String appId,
+    InstallOperation op, {
+    InstallSource? source,
+  }) {
+    if (source != null) {
+      _operationSourceByAppId[appId] = source;
+    } else {
+      _operationSourceByAppId.putIfAbsent(appId, () => InstallSource.normal);
+    }
     state = state.copyWith(operations: {...state.operations, appId: op});
     _updateWatchdogTimer();
   }
 
   void clearOperation(String appId) {
+    _operationSourceByAppId.remove(appId);
     state = state.copyWith(
       operations: Map.from(state.operations)..remove(appId),
     );
@@ -314,11 +331,20 @@ abstract class PackageManager extends StateNotifier<PackageManagerState> {
   /// Called after the batch completion display timeout.
   /// Terminal states: Completed, OperationFailed, InstallCancelled.
   void clearCompletedOperations() {
+    final completedIds = state.operations.entries
+        .where(
+          (entry) =>
+              entry.value is Completed ||
+              entry.value is OperationFailed ||
+              entry.value is InstallCancelled,
+        )
+        .map((entry) => entry.key)
+        .toSet();
     final remaining = Map.of(state.operations)
-      ..removeWhere(
-        (_, op) =>
-            op is Completed || op is OperationFailed || op is InstallCancelled,
-      );
+      ..removeWhere((appId, _) => completedIds.contains(appId));
+    for (final appId in completedIds) {
+      _operationSourceByAppId.remove(appId);
+    }
     state = state.copyWith(operations: remaining);
     _updateWatchdogTimer();
   }
@@ -333,6 +359,7 @@ abstract class PackageManager extends StateNotifier<PackageManagerState> {
     String appId,
     FileMetadata target, {
     String? displayName,
+    InstallSource source = InstallSource.normal,
   }) async {
     await _ensureDownloaderReady();
     final existing = getOperation(appId);
@@ -366,6 +393,7 @@ abstract class PackageManager extends StateNotifier<PackageManagerState> {
     setOperation(
       appId,
       DownloadQueued(target: target, displayName: displayName),
+      source: source,
     );
 
     // Process queue to potentially start this download immediately
@@ -376,7 +404,14 @@ abstract class PackageManager extends StateNotifier<PackageManagerState> {
   /// Queue multiple downloads at once - staggered to prevent UI flood.
   /// This is the primary method for "Update All" functionality.
   Future<void> queueDownloads(
-    List<({String appId, FileMetadata target, String? displayName})> items,
+    List<
+      ({
+        String appId,
+        FileMetadata target,
+        String? displayName,
+        InstallSource source,
+      })
+    > items,
   ) async {
     await _ensureDownloaderReady();
 
@@ -404,6 +439,7 @@ abstract class PackageManager extends StateNotifier<PackageManagerState> {
         setOperation(
           item.appId,
           DownloadQueued(target: item.target, displayName: item.displayName),
+          source: item.source,
         );
       }
 
@@ -718,6 +754,7 @@ abstract class PackageManager extends StateNotifier<PackageManagerState> {
       appId,
       target.id,
       isCdnRetry: isCdnRetry,
+      source: getOperationSource(appId),
     );
 
     final task = DownloadTask(
@@ -771,9 +808,10 @@ abstract class PackageManager extends StateNotifier<PackageManagerState> {
     final metaData = update.task.metaData;
     bool isCdnRetry = false;
     if (metaData.isNotEmpty) {
-      final (decodedAppId, _, cdnRetry) = _parseTaskMetadata(metaData);
+      final (decodedAppId, _, cdnRetry, source) = _parseTaskMetadata(metaData);
       isCdnRetry = cdnRetry;
       if (decodedAppId != null) {
+        _operationSourceByAppId.putIfAbsent(decodedAppId, () => source);
         final op = getOperation(decodedAppId);
         // Ensure the operation actually matches this taskId (metadata could be stale).
         if (op is Downloading && op.taskId == update.task.taskId) {
@@ -1181,7 +1219,7 @@ abstract class PackageManager extends StateNotifier<PackageManagerState> {
           continue;
         }
 
-        final (appId, metadataId, _) = _parseTaskMetadata(metaData);
+        final (appId, metadataId, _, source) = _parseTaskMetadata(metaData);
         if (appId == null) {
           await _cleanupTask(task);
           continue;
@@ -1199,7 +1237,7 @@ abstract class PackageManager extends StateNotifier<PackageManagerState> {
           continue;
         }
 
-        await _restoreOperation(appId, record, task, fileMetadata);
+        await _restoreOperation(appId, record, task, fileMetadata, source);
       }
     } catch (e) {
       debugPrint('Failed to restore operations: $e');
@@ -1211,6 +1249,7 @@ abstract class PackageManager extends StateNotifier<PackageManagerState> {
     TaskRecord record,
     DownloadTask task,
     FileMetadata fileMetadata,
+    InstallSource source,
   ) async {
     switch (record.status) {
       case TaskStatus.complete:
@@ -1237,6 +1276,7 @@ abstract class PackageManager extends StateNotifier<PackageManagerState> {
             progress: record.progress,
             taskId: task.taskId,
           ),
+          source: source,
         );
         try {
           await _downloader.resume(task);
@@ -1263,6 +1303,7 @@ abstract class PackageManager extends StateNotifier<PackageManagerState> {
             progress: record.progress,
             taskId: task.taskId,
           ),
+          source: source,
         );
         break;
 
@@ -1304,19 +1345,29 @@ abstract class PackageManager extends StateNotifier<PackageManagerState> {
     String appId,
     String metadataId, {
     bool isCdnRetry = false,
+    InstallSource source = InstallSource.normal,
   }) {
-    return '$appId|$metadataId|${isCdnRetry ? '1' : '0'}';
+    return '$appId|$metadataId|${isCdnRetry ? '1' : '0'}|${source.name}';
   }
 
-  (String? appId, String? metadataId, bool isCdnRetry) _parseTaskMetadata(
+  (String? appId, String? metadataId, bool isCdnRetry, InstallSource source)
+  _parseTaskMetadata(
     String metaData,
   ) {
     final parts = metaData.split('|');
     if (parts.length >= 2) {
       final isCdnRetry = parts.length >= 3 && parts[2] == '1';
-      return (parts[0], parts[1], isCdnRetry);
+      final source = InstallSource.fromMetadata(
+        parts.length >= 4 ? parts[3] : null,
+      );
+      return (parts[0], parts[1], isCdnRetry, source);
     }
-    return (metaData.isNotEmpty ? metaData : null, null, false);
+    return (
+      metaData.isNotEmpty ? metaData : null,
+      null,
+      false,
+      InstallSource.normal,
+    );
   }
 
   Future<FileMetadata?> _loadFileMetadata(

--- a/lib/services/secure_storage_service.dart
+++ b/lib/services/secure_storage_service.dart
@@ -126,6 +126,26 @@ class SecureStorageService {
       value: jsonEncode(relays.toList()),
     );
   }
+
+  // =========================================================================
+  // Installed Apps Backup
+  // =========================================================================
+
+  static const _backupEnabledKey = 'installed_apps_backup_enabled';
+
+  /// Whether installed apps backup is enabled (off by default).
+  Future<bool> getBackupEnabled() async {
+    final value = await _storage.read(key: _backupEnabledKey);
+    return value == 'true';
+  }
+
+  /// Store the installed apps backup toggle state.
+  Future<void> setBackupEnabled(bool enabled) async {
+    await _storage.write(
+      key: _backupEnabledKey,
+      value: enabled.toString(),
+    );
+  }
 }
 
 /// Persists the AmberSigner pubkey in flutter_secure_storage.

--- a/lib/widgets/app_card.dart
+++ b/lib/widgets/app_card.dart
@@ -25,6 +25,17 @@ class AppCard extends HookConsumerWidget {
   final bool showUpdateButton;
   final bool showZapEncouragement;
   final bool showDescription;
+  final InstallSource installSource;
+
+  /// When provided, used instead of default navigation on tap.
+  /// Use when AppCard is shown outside GoRouter tree (e.g. in a dialog).
+  final VoidCallback? onTap;
+
+  /// When true, tap is disabled (e.g. informational display only).
+  final bool ignorePointer;
+
+  /// When true, show install button even when app has no update (e.g. restore "to install").
+  final bool showInstallWhenNotInstalled;
 
   const AppCard({
     super.key,
@@ -35,6 +46,10 @@ class AppCard extends HookConsumerWidget {
     this.showUpdateButton = false,
     this.showZapEncouragement = false,
     this.showDescription = true,
+    this.installSource = InstallSource.normal,
+    this.onTap,
+    this.ignorePointer = false,
+    this.showInstallWhenNotInstalled = false,
   });
 
   @override
@@ -54,121 +69,139 @@ class AppCard extends HookConsumerWidget {
         ? _stripMarkdown(app!.description)
         : 'No description available';
 
-    Widget buildCard(Profile? publisher, bool isPublisherLoading) => GestureDetector(
-      onTap: () {
-        final segments = GoRouterState.of(context).uri.pathSegments;
-        final first = segments.isNotEmpty ? segments.first : 'search';
-        // Prefer naddr so the detail screen can uniquely identify the app
-        // (identifier + author) and not accidentally resolve to a different
-        // publisher's app with the same identifier.
-        final naddr = Utils.encodeShareableIdentifier(
-          AddressInput(
-            identifier: app!.identifier,
-            author: app!.pubkey,
-            kind: app!.event.kind,
-            relays: const [],
-          ),
-        );
-        context.push('/$first/app/$naddr');
-      },
-      child: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(20),
-          color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.6),
-          border: Border.all(
-            color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
-            width: 1,
-          ),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Header row: Icon + Name/Version (icon matches header height)
-            LayoutBuilder(
-              builder: (context, constraints) {
-                // Icon takes a little over 20% of available width
-                final iconSize = (constraints.maxWidth * 0.21).clamp(
-                  50.0,
-                  68.0,
-                );
-                return Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // App Icon (stretches to match name + version height, ~20% width)
-                    _buildAppIcon(context, iconSize),
-
-                    const SizedBox(width: 14),
-
-                    // App Name and Version (always stacked)
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          // App name with optional "by publisher" inline
-                          _buildAppNameWithPublisher(context, publisher, isPublisherLoading),
-                          const SizedBox(height: 8),
-                          Align(
-                            alignment: Alignment.centerLeft,
-                            child: VersionPillWidget(
-                              app: app!,
-                              showUpdateArrow: showUpdateArrow,
-                            ),
-                          ),
-                        ],
+    Widget buildCard(Profile? publisher, bool isPublisherLoading) {
+      final card = GestureDetector(
+        onTap: ignorePointer
+            ? null
+            : (onTap ??
+                  () {
+                    final segments = GoRouterState.of(context).uri.pathSegments;
+                    final first = segments.isNotEmpty
+                        ? segments.first
+                        : 'search';
+                    final naddr = Utils.encodeShareableIdentifier(
+                      AddressInput(
+                        identifier: app!.identifier,
+                        author: app!.pubkey,
+                        kind: app!.event.kind,
+                        relays: const [],
                       ),
-                    ),
-                  ],
-                );
-              },
+                    );
+                    context.push('/$first/app/$naddr');
+                  }),
+        child: Container(
+          margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.6),
+            border: Border.all(
+              color: Theme.of(
+                context,
+              ).colorScheme.outline.withValues(alpha: 0.2),
+              width: 1,
             ),
-
-            // App Description rendered as plain text (markdown stripped)
-            if (showDescription) ...[
-              const SizedBox(height: 10),
-              Text(
-                descriptionText,
-                style: descriptionStyle,
-                overflow: TextOverflow.ellipsis,
-                maxLines: 2,
-                softWrap: true,
-              ),
-            ],
-
-            // Update button (for apps with updates or currently downloading/installing)
-            if (showUpdateButton)
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Header row: Icon + Name/Version (icon matches header height)
               LayoutBuilder(
                 builder: (context, constraints) {
-                  // Match the text column start (icon width + spacing)
+                  // Icon takes a little over 20% of available width
                   final iconSize = (constraints.maxWidth * 0.21).clamp(
                     50.0,
                     68.0,
                   );
-                  final leftInset = iconSize + 14;
+                  return Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // App Icon (stretches to match name + version height, ~20% width)
+                      _buildAppIcon(context, iconSize),
 
-                  return Padding(
-                    padding: EdgeInsets.only(left: leftInset),
-                    child: SizedBox(
-                      width: (constraints.maxWidth - leftInset).clamp(
-                        0.0,
-                        constraints.maxWidth,
+                      const SizedBox(width: 14),
+
+                      // App Name and Version (always stacked)
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            // App name with optional "by publisher" inline
+                            _buildAppNameWithPublisher(
+                              context,
+                              publisher,
+                              isPublisherLoading,
+                            ),
+                            const SizedBox(height: 8),
+                            Align(
+                              alignment: Alignment.centerLeft,
+                              child: VersionPillWidget(
+                                app: app!,
+                                showUpdateArrow: showUpdateArrow,
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
-                      child: _AppCardUpdateButtonSection(app: app!),
-                    ),
+                    ],
                   );
                 },
               ),
 
-            // Zap encouragement (only for downloading/installing developer-signed apps)
-            if (showZapEncouragement)
-              _AppCardZapEncouragementSection(app: app!, publisher: publisher),
-          ],
+              // App Description rendered as plain text (markdown stripped)
+              if (showDescription) ...[
+                const SizedBox(height: 10),
+                Text(
+                  descriptionText,
+                  style: descriptionStyle,
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 2,
+                  softWrap: true,
+                ),
+              ],
+
+              // Update button (for apps with updates or currently downloading/installing)
+              if (showUpdateButton || showInstallWhenNotInstalled)
+                LayoutBuilder(
+                  builder: (context, constraints) {
+                    // Match the text column start (icon width + spacing)
+                    final iconSize = (constraints.maxWidth * 0.21).clamp(
+                      50.0,
+                      68.0,
+                    );
+                    final leftInset = iconSize + 14;
+
+                    return Padding(
+                      padding: EdgeInsets.only(left: leftInset),
+                      child: SizedBox(
+                        width: (constraints.maxWidth - leftInset).clamp(
+                          0.0,
+                          constraints.maxWidth,
+                        ),
+                        child: _AppCardUpdateButtonSection(
+                          app: app!,
+                          installSource: installSource,
+                          showWhenNotInstalled: showInstallWhenNotInstalled,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+
+              // Zap encouragement (only for downloading/installing developer-signed apps)
+              if (showZapEncouragement)
+                _AppCardZapEncouragementSection(
+                  app: app!,
+                  publisher: publisher,
+                ),
+            ],
+          ),
         ),
-      ),
-    );
+      );
+      return card;
+    }
 
     if (!needsPublisher) return buildCard(null, false);
 
@@ -452,15 +485,24 @@ class AppCard extends HookConsumerWidget {
 }
 
 class _AppCardUpdateButtonSection extends ConsumerWidget {
-  const _AppCardUpdateButtonSection({required this.app});
+  const _AppCardUpdateButtonSection({
+    required this.app,
+    this.installSource = InstallSource.normal,
+    this.showWhenNotInstalled = false,
+  });
 
   final App app;
+  final InstallSource installSource;
+  final bool showWhenNotInstalled;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final operation = ref.watch(installOperationProvider(app.identifier));
+    final installedPkg = ref.watch(installedPackageProvider(app.identifier));
     final hasOperation = operation != null;
-    final shouldShow = app.hasUpdate || hasOperation;
+    final isInstalled = installedPkg != null;
+    final shouldShow =
+        app.hasUpdate || hasOperation || (showWhenNotInstalled && !isInstalled);
 
     if (!shouldShow) return const SizedBox.shrink();
 
@@ -472,6 +514,7 @@ class _AppCardUpdateButtonSection extends ConsumerWidget {
           child: _CompactInstallButton(
             app: app,
             release: app.latestRelease.value,
+            installSource: installSource,
           ),
         ),
       ],
@@ -512,12 +555,22 @@ class _AppCardZapEncouragementSection extends ConsumerWidget {
 class _CompactInstallButton extends ConsumerWidget {
   final App app;
   final Release? release;
+  final InstallSource installSource;
 
-  const _CompactInstallButton({required this.app, this.release});
+  const _CompactInstallButton({
+    required this.app,
+    this.release,
+    this.installSource = InstallSource.normal,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return InstallButton(app: app, release: release, compact: true);
+    return InstallButton(
+      app: app,
+      release: release,
+      compact: true,
+      installSource: installSource,
+    );
   }
 }
 

--- a/lib/widgets/batch_progress_banner.dart
+++ b/lib/widgets/batch_progress_banner.dart
@@ -5,12 +5,17 @@ import 'package:zapstore/services/package_manager/package_manager.dart';
 import 'package:zapstore/theme.dart';
 import 'package:zapstore/utils/extensions.dart';
 
-/// "Update All" button row.
+/// "Update All" / "Install All" button row.
 /// Progress and "All done" states are handled by sticky banners in _UpdatesListBody.
 class UpdateAllRow extends ConsumerWidget {
-  const UpdateAllRow({super.key, required this.allUpdates});
+  const UpdateAllRow({
+    super.key,
+    required this.allUpdates,
+    this.label = 'Update All',
+  });
 
   final List<App> allUpdates;
+  final String label;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -38,7 +43,7 @@ class UpdateAllRow extends ConsumerWidget {
         },
         icon: const Icon(Icons.download, size: 16, color: Colors.white),
         label: Text(
-          'Update All (${allUpdates.length})',
+          '$label (${allUpdates.length})',
           style: const TextStyle(
             fontSize: 14,
             fontWeight: FontWeight.w600,

--- a/lib/widgets/batch_progress_banner.dart
+++ b/lib/widgets/batch_progress_banner.dart
@@ -12,10 +12,12 @@ class UpdateAllRow extends ConsumerWidget {
     super.key,
     required this.allUpdates,
     this.label = 'Update All',
+    this.installSource = InstallSource.normal,
   });
 
   final List<App> allUpdates;
   final String label;
+  final InstallSource installSource;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -36,6 +38,7 @@ class UpdateAllRow extends ConsumerWidget {
                   appId: app.identifier,
                   target: app.latestFileMetadata!,
                   displayName: app.name,
+                  source: installSource,
                 ),
               )
               .toList();

--- a/lib/widgets/bookmark_widgets.dart
+++ b/lib/widgets/bookmark_widgets.dart
@@ -299,7 +299,11 @@ class _AddToStackDialogSignedIn extends HookConsumerWidget {
             (t) => t is List && t.isNotEmpty && t[0] == 'd',
             orElse: () => null,
           );
-          if (dTag != null && dTag[1] == kAppBookmarksIdentifier) return false;
+          if (dTag != null &&
+              (dTag[1] == kAppBookmarksIdentifier ||
+                  dTag[1] == kInstalledAppsBackupIdentifier)) {
+            return false;
+          }
           // Check has at least one 'a' tag (app reference)
           final hasAppRef = tags.any(
             (t) => t is List && t.isNotEmpty && t[0] == 'a',

--- a/lib/widgets/install_button.dart
+++ b/lib/widgets/install_button.dart
@@ -18,11 +18,13 @@ class InstallButton extends ConsumerWidget {
     required this.app,
     this.release,
     this.compact = false,
+    this.installSource = InstallSource.normal,
   });
 
   final App app;
   final Release? release;
   final bool compact;
+  final InstallSource installSource;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -564,7 +566,12 @@ class InstallButton extends ConsumerWidget {
     FileMetadata fileMetadata,
   ) async {
     final pm = ref.read(packageManagerProvider.notifier);
-    await pm.startDownload(app.identifier, fileMetadata, displayName: app.name);
+    await pm.startDownload(
+      app.identifier,
+      fileMetadata,
+      displayName: app.name,
+      source: installSource,
+    );
   }
 
   void _pauseDownload(WidgetRef ref) {


### PR DESCRIPTION
**Closes #20**

### Problem

Users who reinstall Zapstore or switch devices lose the list of apps they had installed. There was no way to keep or restore that list.

We added backup and restore for installed apps using the same pattern as bookmarks: an encrypted AppStack (kind 30267) stored on Nostr social relays with NIP-44 encryption. Only apps that are both installed and in the Zapstore catalog are included.

**Backup:** Collects all cataloged installed apps, builds addressable IDs (`kind:pubkey:identifier`), encrypts them, and publishes to social relays.

**Restore:** Fetches the backup from relays, decrypts it, resolves IDs to App models, and shows a full-screen list split into "To install" and "Already installed", with an "Install All" option when there are multiple apps to install.

### Current UX

For now, backup and restore are manual actions via two tiles in Profile → Data Management: "Backup installed apps" and "Restore installed apps". Both require sign-in.

### Open decisions

1. **Automatic triggers:** It still needs to be decided if and when backup/restore should run automatically, for example:
   - On app startup (e.g. after sign-in)
   - On sign-in
   - When installing or uninstalling apps
   - On a schedule (e.g. periodic backup)

2. **UX/UI review:** The restore screen and Data Management section should be reviewed by the UX/UI team to confirm the flow and layout, and to suggest changes if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backup and restore installed apps: sign-in gated backup, toggle in Profile, and a Restore screen with "Install All" and per-app restore actions.
  * Automatic background backup listener to keep backups up to date.
  * Update/Install batch controls now support customizable labels.

* **Improvements**
  * App cards and install buttons accept context for restore installs and improved tap/interaction handling.

* **Bug Fixes**
  * Excluded backup-tagged stacks from bookmark/add-to-stack dialogs to avoid duplicate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->