### PR TITLE
Include relay hint in naddr for app events

### DIFF
--- a/lib/constants/app_constants.dart
+++ b/lib/constants/app_constants.dart
@@ -39,6 +39,12 @@ bool appStackEventFilter(Map<String, dynamic> event) {
   return false;
 }
 
+/// Authoritative relay for NIP-82 software application events (kind 32267).
+/// Used as the relay hint in naddr encoding so other clients can resolve app events.
+/// Invariant: all Zapstore-published app events are available on this relay.
+/// Stack events (social relays) should NOT use this hint.
+const kDefaultRelay = 'wss://relay.zapstore.dev';
+
 /// Amber signer package ID
 const kAmberPackageId = 'com.greenart7c3.nostrsigner';
 

--- a/lib/screens/app_detail_screen.dart
+++ b/lib/screens/app_detail_screen.dart
@@ -633,7 +633,7 @@ class _AppDetailContent extends HookConsumerWidget {
         identifier: app.identifier,
         author: app.pubkey,
         kind: app.event.kind,
-        relays: [],
+        relays: const [kDefaultRelay],
       ),
     );
     return 'https://zapstore.dev/apps/$naddr';

--- a/lib/widgets/app_card.dart
+++ b/lib/widgets/app_card.dart
@@ -66,7 +66,7 @@ class AppCard extends HookConsumerWidget {
             identifier: app!.identifier,
             author: app!.pubkey,
             kind: app!.event.kind,
-            relays: const [],
+            relays: const [kDefaultRelay],
           ),
         );
         context.push('/$first/app/$naddr');


### PR DESCRIPTION
## Summary

- Add `kDefaultRelay` (`wss://relay.zapstore.dev`) as relay hint in naddr encoding for app events (`app_card.dart`, `app_detail_screen.dart`)
- Add invariant comment documenting that `relay.zapstore.dev` is authoritative for all NIP-82 app events
- Stack naddr calls (`user_screen.dart`, `app_stack_container.dart`) intentionally keep empty relay lists since stacks live on social relays

## Context

Other Nostr clients (Amethyst, Wisp) cannot resolve NIP-82 software application events from naddr references because the relay TLV field was empty. Clients fall back to the author's outbox relays or the user's relay list, neither of which include `relay.zapstore.dev`.

The ZSP publisher already includes relay hints correctly — only the Flutter app was missing them.

Closes #343

## Test plan

- [x] `fvm flutter analyze` passes on changed files
- [x] App naddr encodes with relay hint (`wss://relay.zapstore.dev` round-trips correctly)
- [x] Stack naddr encodes with empty relay list (confirmed null on decode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App links and identifiers now include a default relay hint when shared or used for navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->